### PR TITLE
feature/empty-request-key-error: Simple first pass guard for empty requests

### DIFF
--- a/layers/__init__.py
+++ b/layers/__init__.py
@@ -80,7 +80,7 @@ def get_current_layer_stack(request=None):
     if not LAYER_STACKS:
         build_layer_stacks()
     current = get_current_layer(request)
-    return LAYER_STACKS[current]
+    return LAYER_STACKS.get(current, [])
 
 
 def reset_layer_stacks():


### PR DESCRIPTION
Issue found on Python 3.6.4, Django 1.11.11.

Request is missing during certain, events that trigger `get_current_layer_stack`.
Specifically static tags in templates as well as when loading email templates. 

CRUM package clears the request before statics are fetched, seems middleware does not kick in for static requests.
Email templates will, almost never, make use of a request.

This is an easy temporary band aid, however this might result in developers not being able to figure out why incorrect (none layer) templates are loading.